### PR TITLE
 Changes Set-NssmService to verify if the service is already stopped.

### DIFF
--- a/buildtask/task.json
+++ b/buildtask/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "4",
     "Minor": "2",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "NssmManage $(message)",

--- a/scripts/ManageNssmService.ps1
+++ b/scripts/ManageNssmService.ps1
@@ -231,8 +231,10 @@ function Set-NssmService ($nssmPath, $serviceName, $serviceState, $remoteSession
         "restarted" {
             Invoke-Tool -FileName $nssmPath -Arguments "restart $serviceName" -RemoteSession $remoteSession
         }
-        "stopped"{
-            Invoke-Tool -FileName $nssmPath -Arguments "stop $serviceName" -RemoteSession $remoteSession
+        "stopped" {
+            If((Get-Service $serviceName -ErrorAction Ignore).Status -ne "Stopped") {
+                Invoke-Tool -FileName $nssmPath -Arguments "stop $serviceName" -RemoteSession $remoteSession
+            }
         }
         Default {
             # Should not execute this. if happen some validation is missing.


### PR DESCRIPTION
# What this PR does:
- Changes the task not to stop an already stopped service.
- Adds unit tests

# Why
- In some cases the task's execution is breaking because the service is already stopped.
